### PR TITLE
refactor: use glob of `node:fs/promises` instead `glob`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
 				"@biomejs/biome": "1.9.4",
 				"@swc/jest": "0.2.37",
 				"@types/jest": "29.5.14",
+				"@types/node": "22.10.5",
 				"jest": "29.7.0",
 				"typescript": "5.7.3"
 			}
@@ -1710,12 +1711,13 @@
 			}
 		},
 		"node_modules/@types/node": {
-			"version": "20.10.8",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-20.10.8.tgz",
-			"integrity": "sha512-f8nQs3cLxbAFc00vEU59yf9UyGUftkPaLGfvbVOIDdx2i1b8epBqj2aNGyP19fiyXWvlmZ7qC1XLjAzw/OKIeA==",
+			"version": "22.10.5",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-22.10.5.tgz",
+			"integrity": "sha512-F8Q+SeGimwOo86fiovQh8qiXfFEh2/ocYv7tU5pJ3EXMSSxk1Joj5wefpFK2fHTf/N6HKGSxIDBT9f3gCxXPkQ==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
-				"undici-types": "~5.26.4"
+				"undici-types": "~6.20.0"
 			}
 		},
 		"node_modules/@types/stack-utils": {
@@ -4379,10 +4381,11 @@
 			}
 		},
 		"node_modules/undici-types": {
-			"version": "5.26.5",
-			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
-			"integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
-			"dev": true
+			"version": "6.20.0",
+			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.20.0.tgz",
+			"integrity": "sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/update-browserslist-db": {
 			"version": "1.0.13",

--- a/package.json
+++ b/package.json
@@ -30,6 +30,9 @@
 		"jest": "29.7.0",
 		"typescript": "5.7.3"
 	},
+	"engines": {
+		"node": ">=22.0.0"
+	},
 	"dependencies": {
 		"glob": "11.0.0"
 	},

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
 		"@biomejs/biome": "1.9.4",
 		"@swc/jest": "0.2.37",
 		"@types/jest": "29.5.14",
+		"@types/node": "22.10.5",
 		"jest": "29.7.0",
 		"typescript": "5.7.3"
 	},

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
+import { glob } from "node:fs/promises";
 import path from "node:path";
-import { glob } from "glob";
 import type { Config } from "./config";
 import {
 	convertPageFilePathToRoute,
@@ -19,7 +19,9 @@ export const generateNextjsSSGRewriteRule = async (
 		config.pagesDirPath,
 		"**/*.{js,jsx,ts,tsx}",
 	);
-	const pageFilePathList = await glob(pagesFilePathPattern);
+	const pageFilePathList = await Array.fromAsync(
+		await glob(pagesFilePathPattern),
+	);
 
 	const routes = pageFilePathList.map((pageFilePath) =>
 		convertPageFilePathToRoute(pageFilePath, config),


### PR DESCRIPTION
⚠️ Warning: [`glob` of `node:fs/promises`](https://nodejs.org/api/fs.html#fspromisesglobpattern-options) is still in experimental.

This change aims to use `glob` of `node:fs/promises` and to remove the [`glob`](https://www.npmjs.com/package/glob) package.
